### PR TITLE
fix: fix fastembed imports

### DIFF
--- a/notebooks/01-qdrant-indexing.ipynb
+++ b/notebooks/01-qdrant-indexing.ipynb
@@ -21,6 +21,34 @@
    "outputs": [
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0ffb540136af44beb9f57fcffe57f904",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading data:   0%|          | 0.00/4.58M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd6d32ade33e4c9589d1790b22b70c27",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating corpus split:   0%|          | 0/5183 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
       "text/plain": [
        "{'_id': '4983',\n",
        " 'title': 'Microstructural development of human newborn cerebral white matter assessed in vivo by diffusion tensor magnetic resonance imaging.',\n",
@@ -87,16 +115,9 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-07-18 17:10:50.908\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mfastembed.embedding\u001b[0m:\u001b[36m<module>\u001b[0m:\u001b[36m7\u001b[0m - \u001b[33m\u001b[1mDefaultEmbedding, FlagEmbedding, JinaEmbedding are deprecated.Use from fastembed import TextEmbedding instead.\u001b[0m\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "92583f75dd5f441680e3a572c87565b2",
+       "model_id": "b4c5a1b6092b457e8f6bead0826b8318",
        "version_major": 2,
        "version_minor": 0
       },
@@ -119,7 +140,7 @@
     }
    ],
    "source": [
-    "from fastembed.embedding import TextEmbedding\n",
+    "from fastembed import TextEmbedding\n",
     "\n",
     "dense_embedding_model = TextEmbedding(\"sentence-transformers/all-MiniLM-L6-v2\")\n",
     "dense_embeddings = list(dense_embedding_model.passage_embed(dataset[\"text\"][0:1]))\n",
@@ -176,12 +197,418 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7dc98341ee0749e9806c9711f97c7656",
+       "model_id": "1e67bb335e254321b8d66e728c82373a",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Fetching 1 files:   0%|          | 0/1 [00:00<?, ?it/s]"
+       "Fetching 29 files:   0%|          | 0/29 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4e3558bf74bb4a8c870d94ae1a569817",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "catalan.txt:   0%|          | 0.00/1.56k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8d8d4e2287dc4b03a5b77d0b67c5da6a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "arabic.txt:   0%|          | 0.00/6.35k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6d1a3c0637044a2887a2dd9ded8d6ae9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "azerbaijani.txt:   0%|          | 0.00/967 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6655f44a177649639ac99676842dabf2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "dutch.txt:   0%|          | 0.00/453 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3434a497a95d43b99951729286f13b64",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "basque.txt:   0%|          | 0.00/2.20k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1f97d16394f643aa8039d7ceb6418cd6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "bengali.txt:   0%|          | 0.00/5.44k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3bb378aa035047f28f44f6203adc2aee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "chinese.txt:   0%|          | 0.00/5.56k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "55512498a09f42458789f0b7b5205fb1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "danish.txt:   0%|          | 0.00/424 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "342fc820565c4d26b03c61b6a48be596",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "english.txt:   0%|          | 0.00/936 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e0d575922194ef7af8b69eb8552eb0f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "german.txt:   0%|          | 0.00/1.36k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4772d73e2b214ccc89726cb54a6f4cd0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "hinglish.txt:   0%|          | 0.00/5.96k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dc2edb2398454c3c862d24a97dda43b3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "greek.txt:   0%|          | 0.00/2.17k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ecc75f2b749240fc9e3f6177dc2a78b1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "hungarian.txt:   0%|          | 0.00/1.23k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2effdfe15a44bdfbceebe4e10cf4830",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "finnish.txt:   0%|          | 0.00/1.58k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a139eba7008643efa5f186062294f7c7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "hebrew.txt:   0%|          | 0.00/1.84k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2f8443812f64b4abbab41befb236da6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "french.txt:   0%|          | 0.00/813 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bcf2e5939ba04971adab7326cedc45ec",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "kazakh.txt:   0%|          | 0.00/3.88k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df80aa83a5c34faea559002d1b48d47a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "romanian.txt:   0%|          | 0.00/1.91k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "126ce9142457418db66ca7db57352d97",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "nepali.txt:   0%|          | 0.00/3.61k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "899c1be8adce400f8c8a78dfdcb00290",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "russian.txt:   0%|          | 0.00/1.24k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "05d0618850fe4b5eb2779eca629480d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "portuguese.txt:   0%|          | 0.00/1.29k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8fda13ea8249403c9d3fab022109a78e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "norwegian.txt:   0%|          | 0.00/851 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "84c64554d885434d85075077603ca8a1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "indonesian.txt:   0%|          | 0.00/6.45k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8445c696302e4221983209345f9835a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "italian.txt:   0%|          | 0.00/1.65k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7cfc69f0c066449b80c7d3d9d161e13f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "tajik.txt:   0%|          | 0.00/1.82k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "749aa5bdf78f4531807d8faf36d43e9e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "turkish.txt:   0%|          | 0.00/260 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ef85c1aa7c2d4ad8978c5f2f5028bd7b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "slovene.txt:   0%|          | 0.00/16.0k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "769dcff8013c460aa72ee2cd30be1b96",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "swedish.txt:   0%|          | 0.00/559 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "93a45ae1a9ff40f78d6e47a7aad59a91",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "spanish.txt:   0%|          | 0.00/2.18k [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -199,9 +626,9 @@
     }
    ],
    "source": [
-    "from fastembed.sparse.bm25 import Bm25\n",
+    "from fastembed import SparseTextEmbedding\n",
     "\n",
-    "bm25_embedding_model = Bm25(\"Qdrant/bm25\")\n",
+    "bm25_embedding_model = SparseTextEmbedding(\"Qdrant/bm25\")\n",
     "bm25_embeddings = list(bm25_embedding_model.passage_embed(dataset[\"text\"][0:1]))\n",
     "len(bm25_embeddings)"
    ]
@@ -230,7 +657,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c37f214477b34f2abafc809dc1255928",
+       "model_id": "1600ec5021c9442bbe72395e117d3164",
        "version_major": 2,
        "version_minor": 0
       },
@@ -253,7 +680,7 @@
     }
    ],
    "source": [
-    "from fastembed.late_interaction import LateInteractionTextEmbedding\n",
+    "from fastembed import LateInteractionTextEmbedding\n",
     "\n",
     "late_interaction_embedding_model = LateInteractionTextEmbedding(\"colbert-ir/colbertv2.0\")\n",
     "late_interaction_embeddings = list(late_interaction_embedding_model.passage_embed(dataset[\"text\"][0:1]))\n",
@@ -262,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "e4e0690fdd4c36d",
    "metadata": {
     "ExecuteTime": {
@@ -277,7 +704,7 @@
        "431"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -298,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "431ec613-ad0c-4a35-b0da-bb2f69294999",
    "metadata": {},
    "outputs": [
@@ -306,7 +733,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4cea045985b0ea2b1f1785a9f3156f49d404f3d387e4919205ad59c0a05854cc\n"
+      "Unable to find image 'qdrant/qdrant:v1.10.0' locally\n"
      ]
     },
     {
@@ -318,6 +745,25 @@
       "\t- Avoid using `tokenizers` before the fork if possible\n",
       "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "v1.10.0: Pulling from qdrant/qdrant\n",
+      "\n",
+      "\u001b[1B76444520: Pulling fs layer \n",
+      "\u001b[1B3062c8bc: Pulling fs layer \n",
+      "\u001b[1B3168c290: Pulling fs layer \n",
+      "\u001b[1Bb700ef54: Pulling fs layer \n",
+      "\u001b[1Bd049bab8: Pulling fs layer \n",
+      "\u001b[1Be2b94493: Pulling fs layer \n",
+      "\u001b[1B5ed2089d: Pulling fs layer \n",
+      "\u001b[1BDigest: sha256:2e8646f963a64a21b3e3f851719e17668644d1ed386285064c2548a52d16ede8[8A\u001b[2K\u001b[7A\u001b[2K\u001b[6A\u001b[2K\u001b[7A\u001b[2K\u001b[7A\u001b[2K\u001b[7A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2KDownload complete \u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[4A\u001b[2K\u001b[3A\u001b[2K\u001b[8A\u001b[2K\u001b[4A\u001b[2K\u001b[2A\u001b[2K\u001b[4A\u001b[2K\u001b[4A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[8A\u001b[2K\u001b[7A\u001b[2K\u001b[6A\u001b[2K\u001b[5A\u001b[2K\u001b[4A\u001b[2K\u001b[4A\u001b[2K\u001b[4A\u001b[2K\u001b[4A\u001b[2K\u001b[1A\u001b[2K\n",
+      "Status: Downloaded newer image for qdrant/qdrant:v1.10.0\n",
+      "c91c886ff8283dbbeffb6a150c98445b065256485fb6a9ecbde5322ed0ced000\n",
+      "docker: Error response from daemon: driver failed programming external connectivity on endpoint thirsty_jang (1b7a76c83d0b3e8ddcd5f4fdce95669a6541b6db4a23eb519ba359258c22775f): Bind for 0.0.0.0:6334 failed: port is already allocated.\n"
+     ]
     }
    ],
    "source": [
@@ -326,7 +772,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "1f0ba5b8b767ae5b",
    "metadata": {
     "ExecuteTime": {
@@ -341,7 +787,7 @@
        "True"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -375,7 +821,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "238650e7e3ea136e",
    "metadata": {
     "ExecuteTime": {
@@ -390,24 +836,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  1%|█                                                                                                                                                                                             | 7/1295 [00:17<53:55,  2.51s/it]\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[11], line 8\u001b[0m\n\u001b[1;32m      6\u001b[0m dense_embeddings \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(dense_embedding_model\u001b[38;5;241m.\u001b[39mpassage_embed(batch[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtext\u001b[39m\u001b[38;5;124m\"\u001b[39m]))\n\u001b[1;32m      7\u001b[0m bm25_embeddings \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(bm25_embedding_model\u001b[38;5;241m.\u001b[39mpassage_embed(batch[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtext\u001b[39m\u001b[38;5;124m\"\u001b[39m]))\n\u001b[0;32m----> 8\u001b[0m late_interaction_embeddings \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mlist\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mlate_interaction_embedding_model\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpassage_embed\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatch\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtext\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     10\u001b[0m client\u001b[38;5;241m.\u001b[39mupload_points(\n\u001b[1;32m     11\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mscifact\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m     12\u001b[0m     points\u001b[38;5;241m=\u001b[39m[\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     31\u001b[0m     batch_size\u001b[38;5;241m=\u001b[39mbatch_size,  \n\u001b[1;32m     32\u001b[0m )\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/ultimate-hybrid-search-workshop-gQON67yw-py3.10/lib/python3.10/site-packages/fastembed/late_interaction/late_interaction_embedding_base.py:43\u001b[0m, in \u001b[0;36mLateInteractionTextEmbeddingBase.passage_embed\u001b[0;34m(self, texts, **kwargs)\u001b[0m\n\u001b[1;32m     31\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     32\u001b[0m \u001b[38;5;124;03mEmbeds a list of text passages into a list of embeddings.\u001b[39;00m\n\u001b[1;32m     33\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[38;5;124;03m    Iterable[np.ndarray]: The embeddings.\u001b[39;00m\n\u001b[1;32m     40\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     42\u001b[0m \u001b[38;5;66;03m# This is model-specific, so that different models can have specialized implementations\u001b[39;00m\n\u001b[0;32m---> 43\u001b[0m \u001b[38;5;28;01myield from\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39membed(texts, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/ultimate-hybrid-search-workshop-gQON67yw-py3.10/lib/python3.10/site-packages/fastembed/late_interaction/late_interaction_text_embedding.py:93\u001b[0m, in \u001b[0;36mLateInteractionTextEmbedding.embed\u001b[0;34m(self, documents, batch_size, parallel, **kwargs)\u001b[0m\n\u001b[1;32m     71\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21membed\u001b[39m(\n\u001b[1;32m     72\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     73\u001b[0m     documents: Union[\u001b[38;5;28mstr\u001b[39m, Iterable[\u001b[38;5;28mstr\u001b[39m]],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     76\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m     77\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Iterable[np\u001b[38;5;241m.\u001b[39mndarray]:\n\u001b[1;32m     78\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m     79\u001b[0m \u001b[38;5;124;03m    Encode a list of documents into list of embeddings.\u001b[39;00m\n\u001b[1;32m     80\u001b[0m \u001b[38;5;124;03m    We use mean pooling with attention so that the model can handle variable-length inputs.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     91\u001b[0m \u001b[38;5;124;03m        List of embeddings, one per document\u001b[39;00m\n\u001b[1;32m     92\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 93\u001b[0m     \u001b[38;5;28;01myield from\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel\u001b[38;5;241m.\u001b[39membed(documents, batch_size, parallel, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/ultimate-hybrid-search-workshop-gQON67yw-py3.10/lib/python3.10/site-packages/fastembed/late_interaction/colbert.py:169\u001b[0m, in \u001b[0;36mColbert.embed\u001b[0;34m(self, documents, batch_size, parallel, **kwargs)\u001b[0m\n\u001b[1;32m    147\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21membed\u001b[39m(\n\u001b[1;32m    148\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m    149\u001b[0m     documents: Union[\u001b[38;5;28mstr\u001b[39m, Iterable[\u001b[38;5;28mstr\u001b[39m]],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    152\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    153\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Iterable[np\u001b[38;5;241m.\u001b[39mndarray]:\n\u001b[1;32m    154\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    155\u001b[0m \u001b[38;5;124;03m    Encode a list of documents into list of embeddings.\u001b[39;00m\n\u001b[1;32m    156\u001b[0m \u001b[38;5;124;03m    We use mean pooling with attention so that the model can handle variable-length inputs.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    167\u001b[0m \u001b[38;5;124;03m        List of embeddings, one per document\u001b[39;00m\n\u001b[1;32m    168\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 169\u001b[0m     \u001b[38;5;28;01myield from\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_embed_documents(\n\u001b[1;32m    170\u001b[0m         model_name\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel_name,\n\u001b[1;32m    171\u001b[0m         cache_dir\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcache_dir),\n\u001b[1;32m    172\u001b[0m         documents\u001b[38;5;241m=\u001b[39mdocuments,\n\u001b[1;32m    173\u001b[0m         batch_size\u001b[38;5;241m=\u001b[39mbatch_size,\n\u001b[1;32m    174\u001b[0m         parallel\u001b[38;5;241m=\u001b[39mparallel,\n\u001b[1;32m    175\u001b[0m         \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs,\n\u001b[1;32m    176\u001b[0m     )\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/ultimate-hybrid-search-workshop-gQON67yw-py3.10/lib/python3.10/site-packages/fastembed/text/onnx_text_model.py:109\u001b[0m, in \u001b[0;36mOnnxTextModel._embed_documents\u001b[0;34m(self, model_name, cache_dir, documents, batch_size, parallel, **kwargs)\u001b[0m\n\u001b[1;32m    107\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m parallel \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m is_small:\n\u001b[1;32m    108\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m batch \u001b[38;5;129;01min\u001b[39;00m iter_batch(documents, batch_size):\n\u001b[0;32m--> 109\u001b[0m         \u001b[38;5;28;01myield from\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_post_process_onnx_output(\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43monnx_embed\u001b[49m\u001b[43m(\u001b[49m\u001b[43mbatch\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[1;32m    110\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    111\u001b[0m     start_method \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m    112\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mforkserver\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mforkserver\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m get_all_start_methods() \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mspawn\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    113\u001b[0m     )\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/ultimate-hybrid-search-workshop-gQON67yw-py3.10/lib/python3.10/site-packages/fastembed/text/onnx_text_model.py:78\u001b[0m, in \u001b[0;36mOnnxTextModel.onnx_embed\u001b[0;34m(self, documents, **kwargs)\u001b[0m\n\u001b[1;32m     72\u001b[0m     onnx_input[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtoken_type_ids\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray(\n\u001b[1;32m     73\u001b[0m         [np\u001b[38;5;241m.\u001b[39mzeros(\u001b[38;5;28mlen\u001b[39m(e), dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mint64) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m input_ids], dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mint64\n\u001b[1;32m     74\u001b[0m     )\n\u001b[1;32m     76\u001b[0m onnx_input \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_preprocess_onnx_input(onnx_input, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n\u001b[0;32m---> 78\u001b[0m model_output \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmodel\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mONNX_OUTPUT_NAMES\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43monnx_input\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     79\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m OnnxOutputContext(\n\u001b[1;32m     80\u001b[0m     model_output\u001b[38;5;241m=\u001b[39mmodel_output[\u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m     81\u001b[0m     attention_mask\u001b[38;5;241m=\u001b[39monnx_input\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mattention_mask\u001b[39m\u001b[38;5;124m\"\u001b[39m, attention_mask),\n\u001b[1;32m     82\u001b[0m     input_ids\u001b[38;5;241m=\u001b[39monnx_input\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minput_ids\u001b[39m\u001b[38;5;124m\"\u001b[39m, input_ids),\n\u001b[1;32m     83\u001b[0m )\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/ultimate-hybrid-search-workshop-gQON67yw-py3.10/lib/python3.10/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py:220\u001b[0m, in \u001b[0;36mSession.run\u001b[0;34m(self, output_names, input_feed, run_options)\u001b[0m\n\u001b[1;32m    218\u001b[0m     output_names \u001b[38;5;241m=\u001b[39m [output\u001b[38;5;241m.\u001b[39mname \u001b[38;5;28;01mfor\u001b[39;00m output \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_outputs_meta]\n\u001b[1;32m    219\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 220\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_sess\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43moutput_names\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43minput_feed\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrun_options\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    221\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m C\u001b[38;5;241m.\u001b[39mEPFail \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[1;32m    222\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_enable_fallback:\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+      "1296it [22:14,  1.03s/it]                                                                                        \n"
      ]
     }
    ],
@@ -448,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "5ae256b5-b874-41e4-b633-85c16f29f2c6",
    "metadata": {},
    "outputs": [
@@ -458,7 +887,7 @@
        "True"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -472,7 +901,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "8d8154fe8e865a8",
    "metadata": {},
    "outputs": [
@@ -482,7 +911,7 @@
        "CollectionInfo(status=<CollectionStatus.GREEN: 'green'>, optimizer_status=<OptimizersStatusOneOf.OK: 'ok'>, vectors_count=None, indexed_vectors_count=15549, points_count=5183, segments_count=7, config=CollectionConfig(params=CollectionParams(vectors={'all-MiniLM-L6-v2': VectorParams(size=384, distance=<Distance.COSINE: 'Cosine'>, hnsw_config=None, quantization_config=None, on_disk=None, datatype=None, multivector_config=None), 'colbertv2.0': VectorParams(size=128, distance=<Distance.COSINE: 'Cosine'>, hnsw_config=None, quantization_config=None, on_disk=None, datatype=None, multivector_config=MultiVectorConfig(comparator=<MultiVectorComparator.MAX_SIM: 'max_sim'>))}, shard_number=1, sharding_method=None, replication_factor=1, write_consistency_factor=1, read_fan_out_factor=None, on_disk_payload=True, sparse_vectors={'bm25': SparseVectorParams(index=None, modifier=<Modifier.IDF: 'idf'>)}), hnsw_config=HnswConfig(m=16, ef_construct=100, full_scan_threshold=10000, max_indexing_threads=0, on_disk=False, payload_m=None), optimizer_config=OptimizersConfig(deleted_threshold=0.2, vacuum_min_vector_number=1000, default_segment_number=0, max_segment_size=None, memmap_threshold=None, indexing_threshold=20000, flush_interval_sec=5, max_optimization_threads=None), wal_config=WalConfig(wal_capacity_mb=32, wal_segments_ahead=0), quantization_config=None), payload_schema={})"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/02-hybrid-search.ipynb
+++ b/notebooks/02-hybrid-search.ipynb
@@ -41,16 +41,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m2024-07-18 17:28:57.253\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mfastembed.embedding\u001b[0m:\u001b[36m<module>\u001b[0m:\u001b[36m7\u001b[0m - \u001b[33m\u001b[1mDefaultEmbedding, FlagEmbedding, JinaEmbedding are deprecated.Use from fastembed import TextEmbedding instead.\u001b[0m\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8aeff0db2baf46a1a646d6a7f2e18e22",
+       "model_id": "c95eacebc9b340df9cc719f6aaeb8621",
        "version_major": 2,
        "version_minor": 0
       },
@@ -64,12 +57,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "098bb9cf908d42139a5e283617ba2336",
+       "model_id": "0fb0c81433034c0586707c6572226197",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Fetching 1 files:   0%|          | 0/1 [00:00<?, ?it/s]"
+       "Fetching 29 files:   0%|          | 0/29 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -78,7 +71,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5894535060454c229aa5f7e249c727cd",
+       "model_id": "b0bbab6f2c5140da80f259b0885f60cf",
        "version_major": 2,
        "version_minor": 0
       },
@@ -91,12 +84,10 @@
     }
    ],
    "source": [
-    "from fastembed.embedding import TextEmbedding\n",
-    "from fastembed.sparse.bm25 import Bm25\n",
-    "from fastembed.late_interaction import LateInteractionTextEmbedding\n",
+    "from fastembed import TextEmbedding, SparseTextEmbedding, LateInteractionTextEmbedding\n",
     "\n",
     "dense_embedding_model = TextEmbedding(\"sentence-transformers/all-MiniLM-L6-v2\")\n",
-    "bm25_embedding_model = Bm25(\"Qdrant/bm25\")\n",
+    "bm25_embedding_model = SparseTextEmbedding(\"Qdrant/bm25\")\n",
     "late_interaction_embedding_model = LateInteractionTextEmbedding(\"colbert-ir/colbertv2.0\")"
    ]
   },
@@ -127,7 +118,7 @@
     {
      "data": {
       "text/plain": [
-       "QueryResponse(points=[ScoredPoint(id=13882658, version=1277, score=0.38743758, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=2097256, version=808, score=0.36370263, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=22401061, version=1538, score=0.3489025, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=7485455, version=1049, score=0.33988652, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=11936877, version=1207, score=0.3381256, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=3716075, version=876, score=0.33763093, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=27453479, version=1708, score=0.3360035, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=25953438, version=1671, score=0.3300631, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=13770184, version=1271, score=0.3296343, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=27841037, version=1715, score=0.32777506, payload=None, vector=None, shard_key=None, order_value=None)])"
+       "QueryResponse(points=[ScoredPoint(id=13882658, version=1277, score=0.38743752, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=2097256, version=808, score=0.3637026, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=22401061, version=1538, score=0.34890246, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=7485455, version=1049, score=0.3398865, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=11936877, version=1207, score=0.3381256, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=3716075, version=876, score=0.33763093, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=27453479, version=1708, score=0.33600342, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=25953438, version=1671, score=0.33006305, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=13770184, version=1271, score=0.3296343, payload=None, vector=None, shard_key=None, order_value=None), ScoredPoint(id=27841037, version=1715, score=0.327775, payload=None, vector=None, shard_key=None, order_value=None)])"
       ]
      },
      "execution_count": 4,
@@ -307,7 +298,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1109/1109 [01:22<00:00, 13.38it/s]\n"
+      "100%|████████████████████████████████████████████████████████████████████████| 1109/1109 [00:21<00:00, 51.79it/s]\n"
      ]
     }
    ],
@@ -463,7 +454,7 @@
     {
      "data": {
       "text/plain": [
-       "{'precision@10': 0.09023485784919653, 'mrr@10': 0.6650636686483411}"
+       "{'precision@10': 0.09023485784919653, 'mrr@10': 0.6650499342711952}"
       ]
      },
      "execution_count": 14,
@@ -528,7 +519,7 @@
     {
      "data": {
       "text/plain": [
-       "{'precision@10': 0.0903584672435105, 'mrr@10': 0.6509211842957208}"
+       "{'precision@10': 0.0903584672435105, 'mrr@10': 0.6512164734043596}"
       ]
      },
      "execution_count": 15,
@@ -592,7 +583,7 @@
     {
      "data": {
       "text/plain": [
-       "{'precision@10': 0.09406674907292954, 'mrr@10': 0.692256754370475}"
+       "{'precision@10': 0.09394313967861558, 'mrr@10': 0.6926104145819846}"
       ]
      },
      "execution_count": 16,
@@ -662,7 +653,7 @@
     {
      "data": {
       "text/plain": [
-       "{'precision@10': 0.09245982694684794, 'mrr@10': 0.6767373987089687}"
+       "{'precision@10': 0.09245982694684794, 'mrr@10': 0.6767202307375361}"
       ]
      },
      "execution_count": 17,
@@ -726,7 +717,7 @@
     {
      "data": {
       "text/plain": [
-       "{'precision@10': 0.08974042027194067, 'mrr@10': 0.6655247513096709}"
+       "{'precision@10': 0.08974042027194067, 'mrr@10': 0.665318735652481}"
       ]
      },
      "execution_count": 18,
@@ -788,10 +779,10 @@
        "a    all-MiniLM-L6-v2  0.089ᵇ      0.790ᵇ       0.620ᵇ      0.701ᵇ      0.655ᵇ\n",
        "b    bm25              0.079       0.710        0.575       0.640       0.605\n",
        "c    colbert           0.090ᵇ      0.802ᵇ       0.665ᵃᵇ     0.741ᵃᵇ     0.694ᵃᵇ\n",
-       "d    rrf               0.090ᵇ      0.804ᵇ       0.651ᵃᵇ     0.728ᵃᵇ     0.684ᵃᵇ\n",
-       "e    full_rrf          0.094ᵃᵇᶜᵈᵍ  0.834ᵃᵇᶜᵈᵍ   0.692ᵃᵇᶜᵈᵍ  0.771ᵃᵇᶜᵈᵍ  0.722ᵃᵇᶜᵈᶠᵍ\n",
+       "d    rrf               0.090ᵇ      0.805ᵇ       0.651ᵃᵇ     0.728ᵃᵇ     0.684ᵃᵇ\n",
+       "e    full_rrf          0.094ᵃᵇᶜᵈᵍ  0.833ᵃᵇᶜᵈᵍ   0.693ᵃᵇᶜᵈᵍ  0.771ᵃᵇᶜᵈᵍ  0.722ᵃᵇᶜᵈᶠᵍ\n",
        "f    reranking         0.092ᵃᵇᵍ    0.820ᵃᵇᵍ     0.677ᵃᵇᶜ    0.756ᵃᵇᶜᵈᵍ  0.707ᵃᵇᶜᵈᵍ\n",
-       "g    multistep         0.090ᵇ      0.796ᵇ       0.666ᵃᵇ     0.741ᵃᵇ     0.693ᵃᵇ"
+       "g    multistep         0.090ᵇ      0.796ᵇ       0.665ᵃᵇ     0.741ᵃᵇ     0.693ᵃᵇ"
       ]
      },
      "execution_count": 19,


### PR DESCRIPTION
it is preferred to import embedding classes from fastembed directly, rather than from fastembed.text_embedding, fastembed.late_interaction, etc
Also, bm25 should be used from SparseTextEmbedding and not directly